### PR TITLE
De-dup duplicate events firing

### DIFF
--- a/js/ajax-load.js
+++ b/js/ajax-load.js
@@ -7,7 +7,6 @@ const pushedUrls = [];
 
 // Function to clear URL tracking (useful for navigation or page changes)
 function clearUrlTracking() {
-  console.log('Clearing URL tracking. Previous URLs:', pushedUrls);
   pushedUrls.length = 0;
 }
 
@@ -73,11 +72,8 @@ function load(target, url, infinite) {
     .then(function() { if(infinite){
       const pagingTrigger = target.querySelector('.paging-trigger');
       if (pagingTrigger && !observedElements.includes(pagingTrigger)) {
-        console.log('Adding paging observer to trigger:', pagingTrigger);
         pagingObserver.observe(pagingTrigger);
         observedElements.push(pagingTrigger);
-      } else if (pagingTrigger) {
-        console.log('Duplicate paging observer prevented for trigger:', pagingTrigger);
       }
       enableNextLoadOnView(target);
       initDataAttributes();
@@ -87,47 +83,35 @@ function load(target, url, infinite) {
 function loadOnView(target, url, infinite) {
   // Prevent duplicate observers for the same element
   if (observedElements.includes(target)) {
-    console.log('Duplicate observer prevented for element:', target, 'URL:', url);
     return;
   }
 
-  console.log('Creating new observer for element:', target, 'URL:', url);
   const observer = new IntersectionObserver((entries) => {
 
     if(entries[0].intersectionRatio !== 0) {
       // Element enters the viewport
       if(!entries[0].target.classList.contains('is-loaded')) {
-        console.log('Element entering viewport:', entries[0].target, 'URL:', url);
         // Element has not been loaded yet
         load(target, url, infinite);
         let skipHistory = entries[0].target.hasAttribute('data-skip-history');
         if(!skipHistory) { 
           // Prevent duplicate history pushes for the same URL
           if (!pushedUrls.includes(url)) {
-            console.log('Pushing to history state:', url);
             history.pushState(null, "", url);
             pushedUrls.push(url);
-          } else {
-            console.log('Duplicate history push prevented for URL:', url);
           }
-        } else {
-          console.log('Skipping history push (data-skip-history attribute)');
         }
         entries[0].target.classList.add('is-loaded');
-      } else {
-        console.log('Element already loaded, skipping:', entries[0].target);
       }
 
     } else {
       // Element leaves the viewport
-      console.log('Element leaving viewport:', entries[0].target);
     }
 
   });
   
   observer.observe(target);
   observedElements.push(target);
-  console.log('Total observed elements:', observedElements.length);
 }
 
 
@@ -201,19 +185,15 @@ function updatePaging(source) {
 
 function loadOnComplete(onCompleteUrl, onCompleteTarget) {
   const targets = document.querySelectorAll(onCompleteTarget);
-  console.log(`loadOnComplete`);
-  console.log(`onCompleteUrl: ${onCompleteUrl}`);
-  console.log(`onCompleteTarget: ${onCompleteTarget}`);
 
   return fetch(onCompleteUrl)
     .then(response => response.text())
     .then(html => {
       targets.forEach(target => {
-        console.log(`Apply on complete to target.`);
         target.innerHTML = html;
       });
     })
-    .catch(error => console.error('Error loading on-complete content:', error));
+    .catch(error => {});
 }
 
 
@@ -222,7 +202,6 @@ function loadOnComplete(onCompleteUrl, onCompleteTarget) {
   // Vanilla JS version of Data Attribute DSL
   let targets = document.querySelectorAll('[data-load-on-view]');
   let count   = 0;
-  console.log('Found', targets.length, 'elements with [data-load-on-view] attribute');
   if(targets.length !== 0) {
     targets.forEach((target) => {
       let url      = target.getAttribute('data-load-on-view');
@@ -234,18 +213,14 @@ function loadOnComplete(onCompleteUrl, onCompleteTarget) {
       // count == 0 || loaded ? display = display : display = 'none';
       if(count != 0 && !loaded && !show){display = 'none';}
       target.style.display = display;
-      console.log('Processing element', count + 1, 'of', targets.length, ':', target, 'URL:', url, 'Infinite:', infinite);
       loadOnView(target, url, infinite);
       count++;
     })
     // Register any triggers on the initial page, not just the one's loaded via ALAX
     let pagingTrigger = document.querySelector('.paging-trigger');
     if(pagingTrigger && !observedElements.includes(pagingTrigger)) { 
-      console.log('Adding initial paging observer to trigger:', pagingTrigger);
       pagingObserver.observe(pagingTrigger);
       observedElements.push(pagingTrigger);
-    } else if (pagingTrigger) {
-      console.log('Duplicate initial paging observer prevented for trigger:', pagingTrigger);
     }
   }
 })();


### PR DESCRIPTION
Hey @Hemphill,

Here are the changes we recommended adding to de-dup the duplicate requests getting sent to the browser history. It appears that the observers continue to trigger as the additional AJAX dom elements. This way it'll keep track of the already created observers and only fire the event once when scrolling through the page. 

Thanks,
-Tyler