### PR TITLE
Fixes store locator repeated searches and stuck loading button.

### DIFF
--- a/js/ajax-form.js
+++ b/js/ajax-form.js
@@ -36,8 +36,10 @@ $(function() {
       let $btn = $(this);
       // submit inputs use val and submit buttons use text.
       if ($btn.is('input')) {
+        $btn.data('original-text', $btn.val());
         $btn.val(loadingText);
       } else {
+        $btn.data('original-text', $btn.html());
         $btn.text(loadingText);
       }
       $btn.prop('disabled', true)
@@ -55,6 +57,16 @@ $(function() {
     $submitButtons.prop('disabled', true);
 
     $target.load(url,data,function(){
+      $submitButtons.each(function() {
+        let $btn = $(this);
+        let originalText = $btn.data('original-text');
+        if ($btn.is('input')) {
+          $btn.val(originalText);
+        } else {
+          $btn.html(originalText);
+        }
+        $btn.prop('disabled', false);
+      });
       if(hasClearOnComplete){ clearOnComplete(clearOnCompleteTarget); }
       if(hasHideOnComplete){ hideOnComplete(hideOnCompleteTarget); }
       if(hasShowOnComplete){ showOnComplete(showOnCompleteTarget); }


### PR DESCRIPTION
Uses event delegation so ajax forms loaded via AJAX (e.g. in a modal) get the submit handler. Calls $.rails.enableFormElements after load completes so jquery-ujs re-enables the submit button.